### PR TITLE
prepare does a start flow - it should endFlow on the way out

### DIFF
--- a/src/stmt.zig
+++ b/src/stmt.zig
@@ -80,6 +80,9 @@ pub const Stmt = struct {
 		const aa = self.arena.allocator();
 
 		try conn._reader.startFlow(aa, opts.timeout);
+		defer self.conn._reader.endFlow() catch {
+			self.conn._state = .fail;
+		};
 
 		var buf = self.buf;
 		buf.reset();


### PR DESCRIPTION
applying just this change on top of your arena fix removed the bus error

To test this, I added a tonne of debug.print statements to show the values of the reader.allocator and reader.default_allocator addresses.

It's all good until the first statement gets prepared, and then the reader.allocator gets out of synch. This patch fixes that, and the 2 values stay correctly in synch from there on