### PR TITLE
Free dynamic buffer

### DIFF
--- a/src/reader.zig
+++ b/src/reader.zig
@@ -61,7 +61,7 @@ fn ReaderT(comptime T: type) type {
 		pub fn deinit(self: Self) void {
 			const allocator = self.default_allocator;
 			if (self.static.ptr != self.buf.ptr) {
-				allocator.free(self.buf);
+				self.allocator.free(self.buf);
 			}
 			allocator.free(self.static);
 		}

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -59,11 +59,10 @@ fn ReaderT(comptime T: type) type {
 		}
 
 		pub fn deinit(self: Self) void {
-			const allocator = self.default_allocator;
 			if (self.static.ptr != self.buf.ptr) {
 				self.allocator.free(self.buf);
 			}
-			allocator.free(self.static);
+			self.default_allocator.free(self.static);
 		}
 
 		// Between a call to startFlow and endFlow, the reader can re-use any

--- a/src/stmt.zig
+++ b/src/stmt.zig
@@ -88,9 +88,6 @@ pub const Stmt = struct {
 		const aa = self.arena.allocator();
 
 		try conn._reader.startFlow(aa, opts.timeout);
-		defer self.conn._reader.endFlow() catch {
-			self.conn._state = .fail;
-		};
 
 		var buf = self.buf;
 		buf.reset();

--- a/src/stmt.zig
+++ b/src/stmt.zig
@@ -80,6 +80,9 @@ pub const Stmt = struct {
 		const aa = self.arena.allocator();
 
 		try conn._reader.startFlow(aa, opts.timeout);
+		defer self.conn._reader.endFlow() catch {
+			self.conn._state = .fail;
+		};
 
 		var buf = self.buf;
 		buf.reset();


### PR DESCRIPTION
This little change makes more sense

When there is a dynamic buffer, its always created on the arena, not the base allocator.

So on de-init, it should also be freed from the arena instead of the base allocator.

Tested this on :
- MacOS x86
- FreeBSD x86
- Linux x86
- MacOS arm64

In all cases, it no longer generates a bus error.  Without this patch, I get crashes in different places - bus error on arm, ptrCasts inside the arena code on x86

Id say thats what the problem was - freeing from the wrong allocator was corrupting the allocator and causing an early exit. The debug statements I werent seeing were probably sitting unflushed in the stderr buffer or something ?  

