### PR TITLE
Fix ambiguous reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -561,3 +561,18 @@ The metrics are:
 * `pg_alloc_params` - counts the number of parameter states that were allocated. This indicates that your queries have more parameters than `result_state_size`. If this happens often, consider increasing `result_state_size`.
 * `pg_alloc_columns` - counts the number of columns states that were allocated. This indicates that your queries are returning more columns than `result_state_size`. If this happens often, consider increasing `result_state_size`.
 * `pg_alloc_reader` - counts the number of bytes allocated while reading messages from PostgreSQL. This generally happens as a result of large result (e.g. selecting large text fields). Controlled by the `read_buffer` configuration option.
+
+## Tests
+
+Launch the Postgres database with the provided Docker Compose configuration:
+
+```console
+cd tests/
+docker compose up
+```
+
+Run tests:
+
+```console
+zig build test
+```

--- a/src/types/numeric.zig
+++ b/src/types/numeric.zig
@@ -3,7 +3,6 @@ const buffer = @import("buffer");
 const lib = @import("../lib.zig");
 const types = @import("../types.zig");
 
-const OID = types.OID;
 const Encode = types.Encode;
 
 const math = std.math;

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,0 @@
-from postgres:latest
-
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
-
-env POSTGRES_USER root
-env POSTGRES_PASSWORD root_pw

--- a/tests/compose.yml
+++ b/tests/compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "root_pw"
+      PGDATA: "/var/lib/postgresql/pgdata/"
+      LANG: "en_US.utf8"
+    ports:
+      - 5432:5432
+    volumes:
+      - "./pg_hba.conf:/etc/postgresql/pg_hba.conf:ro"
+    command:
+      - "postgres"
+      - "-c"
+      - "hba_file=/etc/postgresql/pg_hba.conf"


### PR DESCRIPTION
Fixes:

```
/home/bob/dev/zig/pg.zig/src/types/numeric.zig:37:26: error: ambiguous reference
    pub const oid = types.OID.make(1700);
                    ~~~~~^~~~
/home/bob/dev/zig/pg.zig/src/types.zig:7:5: note: declared here
pub const OID = struct {
~~~~^~~~~
/home/bob/dev/zig/pg.zig/src/types/numeric.zig:6:1: note: declared here
const OID = types.OID;
^~~~~~~~~~~~~~~~~~~~~
```

Add Docker Compose config for consistent test environment setup.

@karlseguin I can remove the Docker Compose stuff if you prefer to use a vanilla Dockerfile but I had some issues getting the test environment running without manually editing files in the container - happy to revert if you don't want to use Docker Compose.