### PR TITLE
Expose result mapper type.

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -16,6 +16,7 @@ pub const Row = result.Row;
 pub const Result = result.Result;
 pub const Iterator = result.Iterator;
 pub const QueryRow = result.QueryRow;
+pub const Mapper = result.Mapper;
 
 const reader = @import("reader.zig");
 pub const Reader = reader.Reader;

--- a/src/pg.zig
+++ b/src/pg.zig
@@ -8,6 +8,7 @@ pub const Stmt = lib.Stmt;
 pub const Result = lib.Result;
 pub const Iterator = lib.Iterator;
 pub const QueryRow = lib.QueryRow;
+pub const Mapper = lib.Mapper;
 
 pub const Listener = @import("listener.zig").Listener;
 


### PR DESCRIPTION
The mapper type is really useful for generic parse functions. For example, I need it for my library ([zrm](https://code.zeptotech.net/zedd/zrm)), see this file where I can remove a TODO with the mapper type exposed: https://code.zeptotech.net/zedd/zrm/src/commit/f186b99fde61d03944c84b354808d4371a78a10e/src/query.zig#L223