### PR TITLE
Unlock mutex on Pool.acquire() error

### DIFF
--- a/src/pool.zig
+++ b/src/pool.zig
@@ -103,6 +103,7 @@ pub const Pool = struct {
     pub fn acquire(self: *Pool) !*Conn {
         const conns = self._conns;
         self._mutex.lock();
+        errdefer self._mutex.unlock();
         while (true) {
             const available = self._available;
             if (available == 0) {


### PR DESCRIPTION
If `Pool.acquire()` errors (e.g. due to a connection timeout) the pool's mutex is never unlocked which results in deadlocks. Unlocking the mutex with `errdefer` resolves the deadlock.