### PR TITLE
Export Error type 

### DIFF
--- a/src/pg.zig
+++ b/src/pg.zig
@@ -15,6 +15,7 @@ pub const Listener = @import("listener.zig").Listener;
 pub const types = lib.types;
 pub const Cidr = types.Cidr;
 pub const Numeric = types.Numeric;
+pub const Error = lib.proto.Error;
 pub const printSSLError = lib.printSSLError;
 
 pub fn uuidToHex(uuid: []const u8) ![36]u8 {


### PR DESCRIPTION
I am writing a `sqlc` generator for Zig using `pg.zig` over [here](https://github.com/tinyzimmer/sqlc-gen-zig). One of the features I'd like to add is being able to return a union of the result or underlying `Error` if present, for example:

```zig
const Result = union {
    user: models.User,
    err: pg.Error,
};
fn getUser(id: i32) !Result
```

This would be a lot cleaner if the `Error` type was publicly available. 