### PR TITLE
fix: added field access for opts to initUri

### DIFF
--- a/src/pool.zig
+++ b/src/pool.zig
@@ -34,8 +34,8 @@ pub const Pool = struct {
     pub fn initUri(allocator: Allocator, uri: std.Uri, opts: Opts) !*Pool {
         var po = try lib.parseOpts(uri, allocator);
         defer po.deinit();
-        po.size = opts.size;
-        po.timeout = opts.timeout;
+        po.opts.size = opts.size;
+        po.opts.timeout = opts.timeout;
         return Pool.init(allocator, po.opts);
     }
 


### PR DESCRIPTION
Added field access to `opts` on `po` in `/src/pool.zig`.