### PR TITLE
general: Add `column_names` build option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,9 +47,17 @@ pub fn build(b: *std.Build) !void {
         pg_module.linkSystemLibrary(openssl_lib_name orelse "ssl", .{});
     }
 
+    var column_names = false;
+    const column_names_opt = b.option(bool, "column_names", "");
+
+    if (column_names_opt) |val| {
+        column_names = val;
+    }
+
     {
         const options = b.addOptions();
         options.addOption(bool, "openssl", openssl);
+        options.addOption(bool, "column_names", column_names);
         pg_module.addOptions("config", options);
     }
 
@@ -62,8 +70,8 @@ pub fn build(b: *std.Build) !void {
             .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
         });
         addLibs(lib_test, modules);
-        lib_test.addLibraryPath(std.Build.LazyPath{.cwd_relative = "/opt/openssl/lib"});
-        lib_test.addIncludePath(std.Build.LazyPath{.cwd_relative = "/opt/openssl/include"});
+        lib_test.addLibraryPath(std.Build.LazyPath{ .cwd_relative = "/opt/openssl/lib" });
+        lib_test.addIncludePath(std.Build.LazyPath{ .cwd_relative = "/opt/openssl/include" });
         lib_test.linkSystemLibrary("crypto");
         lib_test.linkSystemLibrary("ssl");
 

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -102,7 +102,7 @@ pub const Conn = struct {
 
     pub const QueryOpts = struct {
         timeout: ?u32 = null,
-        column_names: bool = false,
+        column_names: bool = lib.default_column_names,
 
         allocator: ?Allocator = null,
         // Whether a call to result.deinit() should automatically release the

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -6,6 +6,8 @@ const openssl = @cImport({
     @cInclude("openssl/err.h");
 });
 
+const build_config = @import("config");
+
 pub const log = std.log.scoped(.pg);
 
 pub const types = @import("types.zig");
@@ -16,8 +18,9 @@ pub const Stmt = @import("stmt.zig").Stmt;
 pub const Pool = @import("pool.zig").Pool;
 pub const Stream = @import("stream.zig").Stream;
 pub const metrics = @import("metrics.zig");
-pub const has_openssl = @import("config").openssl;
+pub const has_openssl = build_config.openssl;
 pub const SSLCtx = if (has_openssl) openssl.SSL_CTX else void;
+pub const default_column_names = build_config.column_names;
 
 const result = @import("result.zig");
 pub const Row = result.Row;


### PR DESCRIPTION
Allows developers to optionally execute all queries as if the
`column_names` option was set to true.

Closes https://github.com/karlseguin/pg.zig/issues/73
