### PR TITLE
result: Make fromPgzRow() take bytes directly

### DIFF
--- a/src/result.zig
+++ b/src/result.zig
@@ -259,7 +259,7 @@ pub const Row = struct {
             },
             .@"struct" => blk: {
                 if (@hasDecl(T, "fromPgzRow") == true) {
-                    return T.fromPgzRow(value, self.oids[col]);
+                    return T.fromPgzRow(value.data, self.oids[col]);
                 }
                 break :blk T;
             },
@@ -284,7 +284,7 @@ pub const Row = struct {
             .optional => |opt| if (value.is_null) return null else opt.child,
             else => T,
         };
-        return Iterator(TT).fromPgzRow(value, self.oids[col]);
+        return Iterator(TT).fromPgzRow(value.data, self.oids[col]);
     }
 
     pub fn iteratorCol(self: *const Row, comptime T: type, name: []const u8) IteratorReturnType(T) {
@@ -503,7 +503,7 @@ pub fn Iterator(comptime T: type) type {
         }
 
         // used internally by row.get(Iterator(T))
-        fn fromPgzRow(value: Result.State.Value, oid: i32) Self {
+        fn fromPgzRow(data: []const u8, oid: i32) Self {
             const TT = switch (@typeInfo(T)) {
                 .optional => |opt| opt.child,
                 else => T,
@@ -566,7 +566,6 @@ pub fn Iterator(comptime T: type) type {
                 },
             };
 
-            const data = value.data;
             if (data.len == 12) {
                 // we have an empty
                 return .{


### PR DESCRIPTION
Allows developers of other libraries to implement this function
without depending directly on pg.zig.

Related to #75 