### PR TITLE
Add `Conn.execIgnoringState`

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -550,6 +550,7 @@ pub const Conn = struct {
     }
 };
 
+const t = lib.testing;
 test "Conn: auth trust (no pass)" {
     var conn = try Conn.open(t.allocator, .{});
     defer conn.deinit();

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -426,12 +426,16 @@ pub const Conn = struct {
     // just skipping over any data rows or any other in-flight messages there
     // might be.
     pub fn rollback(self: *Conn) !void {
+        return self.execIgnoringState("rollback");
+    }
+
+    pub fn execIgnoringState(self: *Conn, sql: []const u8) !void {
         var buf = &self._buf;
         buf.reset();
 
         const state = self._state;
 
-        const simple_query = proto.Query{ .sql = "rollback" };
+        const simple_query = proto.Query{ .sql = sql };
         try simple_query.write(buf);
         try self.write(buf.string());
         while (true) {
@@ -546,7 +550,6 @@ pub const Conn = struct {
     }
 };
 
-const t = lib.testing;
 test "Conn: auth trust (no pass)" {
     var conn = try Conn.open(t.allocator, .{});
     defer conn.deinit();


### PR DESCRIPTION
Currently, there doesn't seem to be a good way to execute a `ROLLBACK SAVEPOINT` statement while in a failing transaction.

This change adds a new `Conn.execIgnoringState` method, which has the same behavior as `Conn.rollback`, in that they both ignore the current state of the connection. This allows either to work at any time, even when in a failing transaction.

I've tested this manually in my own codebase, but I haven't written any test cases. Happy to add tests or make any kind of changes if this doesn't feel like a good idea!