### PR TITLE
Fix build.zig compatibility when used as a transitive dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) !void {
     // <openssl/ssl.h> isn't reachable — e.g. when -Dtarget switches Zig into
     // cross-compile mode and stops searching the system include paths.
     const openssl_module = if (openssl) blk: {
-        const Translator = @import("translate_c").Translator;
+        const Translator = @import("vendor/translate-c/build/Translator.zig");
         const translate_c = b.dependency("translate_c", .{});
         const t: Translator = .init(translate_c, .{
             .c_source_file = b.path("src/openssl.h"),
@@ -62,9 +62,9 @@ pub fn build(b: *std.Build) !void {
         pg_module.addOptions("config", options);
     }
 
-    {
+    if (openssl) {
         // test step — always built with openssl enabled
-        const Translator = @import("translate_c").Translator;
+        const Translator = @import("vendor/translate-c/build/Translator.zig");
         const translate_c = b.dependency("translate_c", .{});
         const t: Translator = .init(translate_c, .{
             .c_source_file = b.path("src/openssl.h"),


### PR DESCRIPTION
Fix two compatibility issues that prevent pg.zig from being used as a transitive dependency in Zig 0.16 projects.

  These issues do not surface when running zig build directly inside pg.zig's own directory — they only trigger when another project depends on pg.zig.

## Changes

  1. @import("translate_c") → relative path import

  In Zig 0.16, @import("dependency_name") no longer resolves when the build.zig is compiled in a transitive dependency context (the build runner doesn't expose
  sibling dependency modules to nested build.zig files). Since translate-c is vendored at vendor/translate-c/, switching to a relative-path import works in both
   standalone and transitive scenarios.

  2. Wrap test step in if (openssl)

  The test block unconditionally called b.dependency("translate_c"), which panics with unable to find artifact 'translate-c' at build time when pg.zig is used
  as a dependency and OpenSSL is not enabled. The test step requires OpenSSL anyway (it always builds with openssl enabled), so guarding it with if (openssl) is
   correct.

  Test plan

  - zig build inside pg.zig directory
  - zig build -Dopenssl=true inside pg.zig directory
  - Used as a dependency in another Zig 0.16 project with -Dopenssl=false (default)
  - Used as a dependency in another Zig 0.16 project with -Dopenssl=true