### PR TITLE
Propagate error from PlainStream.shutdown (fixes Zig 0.16 build)

### DIFF
--- a/src/stream.zig
+++ b/src/stream.zig
@@ -171,7 +171,7 @@ const PlainStream = struct {
 
     pub fn shutdown(self: *const PlainStream, how: ShutdownHow) !void {
         const sock = self.stream.socket.handle;
-        sockShutdown(sock, how);
+        return sockShutdown(sock, how);
     }
 
     pub fn writeAll(self: *const PlainStream, data: []const u8) !void {


### PR DESCRIPTION
**disclaimer: claude wrote this**

## Problem

`PlainStream.shutdown` discards the `!void` returned by `sockShutdown`:

```zig
pub fn shutdown(self: *const PlainStream, how: ShutdownHow) !void {
    const sock = self.stream.socket.handle;
    sockShutdown(sock, how);  // <- error union ignored
}
```

Older Zig tolerated ignoring an error union, but **Zig 0.16 makes it a hard compile error** (`error is ignored`). This breaks any build that reaches `PlainStream.shutdown`. It isn't hit through the `Pool` query API (`row`/`exec`/`query`), so most code compiles fine — but instantiating a `Listener` pulls it in via `Listener.deinit()` → `Listener.stop()` → `_stream.shutdown(.both)`, and the build fails.

## Fix

Return the result, matching the sibling `Stream.shutdown` (TLS variant) which already does `return sockShutdown(...)`. One token.

```zig
    return sockShutdown(sock, how);
```