### PR TITLE
Add `Conn.tryRollback`

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -435,6 +435,12 @@ pub const Conn = struct {
         return self.execIgnoringState("rollback");
     }
 
+    pub fn tryRollback(self: *Conn) !void {
+        if (self._state != .idle) {
+            try self.rollback();
+        }
+    }
+
     pub fn execIgnoringState(self: *Conn, sql: []const u8) !void {
         var buf = &self._buf;
         buf.reset();


### PR DESCRIPTION
In our web server codebase, we'd like to only rollback if the connection hasn't been committed yet.

Example (pseudocode-ish):
```zig
const conn = try pool.acquire();
defer conn.release();

try conn.begin();
defer conn.rollback() catch {};

if (error) {
  return 400_RESPONSE;
}

try conn.commit();

return 200_RESPONSE;
```

We don't use standard zig errors in our endpoint handlers, so we can't take advantage of `errdefer`.
This new `Conn.tryRollback` function would be a drop-in replacement for us.

Also, I targeted the 0.15 branch because we're still on that version. Feel free to cherry-pick the changes to master.