### PR TITLE
Propagate error.Canceled instead of swallowing it

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -198,8 +198,7 @@ pub const Conn = struct {
         allocator.free(self._param_oids);
         self._result_state.deinit(allocator);
 
-        // try to send a Terminate to the DB
-        self.write(&.{ 'X', 0, 0, 0, 4 }) catch {};
+        lib.sendTerminate(&self._stream, self._io);
         lib.freeSSLContext(self._ssl_ctx);
         self._stream.close();
 
@@ -401,9 +400,7 @@ pub const Conn = struct {
         var affected: ?i64 = null;
         while (true) {
             const msg = self.read() catch |err| {
-                if (err == error.PG) {
-                    self.readyForQuery() catch {};
-                }
+                if (err == error.PG) try self.recoverFromError();
                 return err;
             };
             switch (msg.type) {
@@ -456,9 +453,7 @@ pub const Conn = struct {
         try self.write(buf.string());
         while (true) {
             const msg = self.read() catch |err| {
-                if (state != .fail and err == error.PG) {
-                    self.readyForQuery() catch {};
-                }
+                if (state != .fail and err == error.PG) try self.recoverFromError();
                 return err;
             };
             switch (msg.type) {
@@ -563,6 +558,14 @@ pub const Conn = struct {
         if (msg.type != 'Z') {
             return self.unexpectedDBMessage();
         }
+    }
+
+    // Drain the trailing ReadyForQuery after a server error so the connection
+    // stays usable. Best-effort, but never swallow a cancellation.
+    pub fn recoverFromError(self: *Conn) error{Canceled}!void {
+        self.readyForQuery() catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+        };
     }
 };
 
@@ -1953,6 +1956,31 @@ test "Conn: TLS verify-full" {
         var conn = try t.connect(.{ .tls = Conn.Opts.TLS{ .verify_full = "tests/root.crt" }, .username = "pgz_user_ssl", .password = "pgz_user_ssl_pw" });
         defer conn.deinit();
     }
+}
+
+test "Conn: query is cancelable" {
+    const S = struct {
+        fn sleepQuery(c: *Conn) !void {
+            var result = try c.query("select pg_sleep(3)", .{});
+            result.deinit();
+        }
+    };
+
+    var conn = try t.connect(.{});
+    defer conn.deinit();
+
+    // Run the query concurrently, let it reach its blocking read, then cancel.
+    var future = try t.io.concurrent(S.sleepQuery, .{&conn});
+    try t.io.sleep(.fromMilliseconds(50), .awake);
+
+    const start = std.Io.Clock.Timestamp.now(t.io, .awake);
+    const result = future.cancel(t.io);
+    const elapsed_ms = start.untilNow(t.io).raw.toMilliseconds();
+
+    try t.expectError(error.Canceled, result);
+    try t.expectEqual(true, elapsed_ms < 1500); // prompt, not blocked until pg_sleep ends
+    try t.expectEqual(Conn.State.fail, conn._state);
+    try t.expectError(error.ConnectionBusy, conn.exec("select 1", .{}));
 }
 
 test "PG: cached query" {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -14,6 +14,7 @@ pub const Conn = @import("conn.zig").Conn;
 pub const Stmt = @import("stmt.zig").Stmt;
 pub const Pool = @import("pool.zig").Pool;
 pub const Stream = @import("stream.zig").Stream;
+pub const sendTerminate = @import("stream.zig").sendTerminate;
 pub const metrics = @import("metrics.zig");
 pub const has_openssl = build_config.openssl;
 pub const SSLCtx = if (has_openssl) openssl.SSL_CTX else void;

--- a/src/listener.zig
+++ b/src/listener.zig
@@ -71,8 +71,7 @@ pub const Listener = struct {
             return;
         }
 
-        // try to send a Terminate to the DB
-        self._stream.writeAll(&.{ 'X', 0, 0, 0, 4 }) catch {};
+        lib.sendTerminate(&self._stream, self._io);
         return self._stream.shutdown(.both);
     }
 

--- a/src/result.zig
+++ b/src/result.zig
@@ -60,7 +60,9 @@ pub const Result = struct {
     // and returning an error union in deinit is a pain for the caller.
     pub fn drain(self: *Result) !void {
         var conn = self._conn;
-        if (conn._state == .idle) {
+        // Only an in-flight query has anything to drain; reading in any other
+        // state (e.g. a poisoned connection) would block.
+        if (conn._state != .query) {
             return;
         }
 

--- a/src/stmt.zig
+++ b/src/stmt.zig
@@ -167,7 +167,7 @@ pub const Stmt = struct {
             // If Parse fails, then the server won't reply to our other messages
             // (i.e. Describe) and it'l immediately send a ReadyForQuery.
             const msg = conn.read() catch |err| {
-                conn.readyForQuery() catch {};
+                if (err == error.PG) try conn.recoverFromError();
                 return err;
             };
 
@@ -341,7 +341,7 @@ pub const Stmt = struct {
 
         {
             const msg = conn.read() catch |err| {
-                conn.readyForQuery() catch {};
+                if (err == error.PG) try conn.recoverFromError();
                 return err;
             };
             if (msg.type != '2') {

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -321,15 +321,30 @@ fn readStream(stream: Io.net.Stream, io: Io, buf: []u8) !usize {
     var vecs: [1][]u8 = .{buf};
     var reader = stream.reader(io, &.{});
     const r = &reader.interface;
-    return try r.readVec(&vecs);
+    return r.readVec(&vecs) catch |err| switch (err) {
+        error.ReadFailed => return reader.err orelse err,
+        else => return err,
+    };
 }
 
 fn writeStream(stream: Io.net.Stream, io: Io, data: []const u8) !void {
     var buf: [1024]u8 = undefined;
     var writer = stream.writer(io, &buf);
     const w = &writer.interface;
-    try w.writeAll(data);
-    try w.flush();
+    w.writeAll(data) catch |err| switch (err) {
+        error.WriteFailed => return writer.err orelse err,
+    };
+    w.flush() catch |err| switch (err) {
+        error.WriteFailed => return writer.err orelse err,
+    };
+}
+
+// Sends a best-effort Terminate ('X') message, shielded from cancellation so
+// teardown can't be interrupted.
+pub fn sendTerminate(stream: *Stream, io: Io) void {
+    const prev = io.swapCancelProtection(.blocked);
+    defer _ = io.swapCancelProtection(prev);
+    stream.writeAll(&.{ 'X', 0, 0, 0, 4 }) catch {};
 }
 
 fn isHostName(host: []const u8) bool {


### PR DESCRIPTION
On an async std.Io a cancelled read/write surfaces as ReadFailed/WriteFailed with the real error.Canceled hidden in the reader's .err, which we dropped. Worse, a read error kicked off a readyForQuery drain that blocked until the query finished, so a query deadline never worked.

Recover the real error in readStream/writeStream, and only drain after a PG error (Conn.recoverFromError still re-raises a cancellation). drain() now skips poisoned connections, and the teardown Terminate writes are shielded from cancellation. Includes a test that cancels an in-flight pg_sleep and checks it fails fast with error.Canceled.