### PR TITLE
fix: handle leading zero groups when weight < -1 in toString and estimatedStringLen

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -1469,7 +1469,8 @@ test "PG: numeric" {
             \\ select 'nan'::numeric, '+Inf'::numeric, '-Inf'::numeric,
             \\ 0::numeric, 0.0::numeric, -0.00009::numeric, -999999.888880::numeric,
             \\ 0.000008, 999999.888807::numeric, 123456.78901234::numeric(14, 8),
-            \\ 0.0000000000000000000000000001::numeric
+            \\ 0.0000000000000000000000000001::numeric, 1000000000000000000000000000::numeric,
+            \\ 1.0::numeric, 10005.00::numeric
         , .{})).?;
         defer row.deinit() catch {};
 
@@ -1484,6 +1485,9 @@ test "PG: numeric" {
         try t.expectEqual(999999.888807, row.get(f64, 8));
         try t.expectEqual(123456.78901234, row.get(f64, 9));
         try expectNumeric(row.get(types.Numeric, 10), "0.0000000000000000000000000001");
+        try expectNumeric(row.get(types.Numeric, 11), "1000000000000000000000000000");
+        try expectNumeric(row.get(types.Numeric, 12), "1.0");
+        try expectNumeric(row.get(types.Numeric, 13), "10005.00");
     }
 
     {
@@ -1533,10 +1537,10 @@ test "PG: numeric" {
         try expectNumeric(row.get(types.Numeric, 15), "1234567.9876543");
         try expectNumeric(row.get(types.Numeric, 16), "12345678.98765432");
         try expectNumeric(row.get(types.Numeric, 17), "123456789.987654321");
-        try expectNumeric(row.get(types.Numeric, 18), "0.0");
-        try expectNumeric(row.get(types.Numeric, 19), "1.0");
-        try expectNumeric(row.get(types.Numeric, 20), "0.0");
-        try expectNumeric(row.get(types.Numeric, 21), "1.0");
+        try expectNumeric(row.get(types.Numeric, 18), "0");
+        try expectNumeric(row.get(types.Numeric, 19), "1");
+        try expectNumeric(row.get(types.Numeric, 20), "0");
+        try expectNumeric(row.get(types.Numeric, 21), "1");
         try expectNumeric(row.get(types.Numeric, 22), "999999999.9999999");
         try expectNumeric(row.get(types.Numeric, 23), "999999999.9999999");
         try expectNumeric(row.get(types.Numeric, 24), "-999999999.9999999");

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -916,7 +916,7 @@ test "PG: type support" {
         try t.expectEqual(1234.567, row.get(f64, 21));
         const arr = try row.iterator(types.Numeric, 22).alloc(aa);
         try t.expectEqual(5, arr.len);
-        try expectNumeric(arr[0], "0.0");
+        try expectNumeric(arr[0], "0");
         try expectNumeric(arr[1], "-1.1");
         try expectNumeric(arr[2], "nan");
         try expectNumeric(arr[3], "inf");

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -1468,7 +1468,8 @@ test "PG: numeric" {
         var row = (try c.rowUnsafe(
             \\ select 'nan'::numeric, '+Inf'::numeric, '-Inf'::numeric,
             \\ 0::numeric, 0.0::numeric, -0.00009::numeric, -999999.888880::numeric,
-            \\ 0.000008, 999999.888807::numeric, 123456.78901234::numeric(14, 8)
+            \\ 0.000008, 999999.888807::numeric, 123456.78901234::numeric(14, 8),
+            \\ 0.0000000000000000000000000001::numeric
         , .{})).?;
         defer row.deinit() catch {};
 
@@ -1482,6 +1483,7 @@ test "PG: numeric" {
         try t.expectEqual(0.000008, row.get(f64, 7));
         try t.expectEqual(999999.888807, row.get(f64, 8));
         try t.expectEqual(123456.78901234, row.get(f64, 9));
+        try expectNumeric(row.get(types.Numeric, 10), "0.0000000000000000000000000001");
     }
 
     {

--- a/src/types/numeric.zig
+++ b/src/types/numeric.zig
@@ -169,6 +169,11 @@ pub const Numeric = struct {
         // a leading 0  (so it'll be 0.123 instead of just .123)
         if (self.weight < 0) {
             l += 1;
+
+            if (self.weight < -1) {
+                const missing_groups: usize = @intCast(-1 - self.weight);
+                l += missing_groups * 4;
+            }
         }
 
         return l;
@@ -234,6 +239,12 @@ pub const Numeric = struct {
             buf[pos] = '0';
             pos += 1;
         } else {
+            while (weight < -1) {
+                @memcpy(buf[pos .. pos + 4], "0000");
+                pos += 4;
+                weight += 1;
+            }
+
             while (digits.len > 0) {
                 const t = std.mem.readInt(i16, digits[0..2], .big);
                 if (t < 10) {

--- a/src/types/numeric.zig
+++ b/src/types/numeric.zig
@@ -161,19 +161,48 @@ pub const Numeric = struct {
 
         // max size per base-10000 digit
         if (self.number_of_digits == 0) {
-            return l + 2; // 0.0  but we already added the decimal place
+            l += 1;
+            // if we have something like 0.000::numeric -> should add '.' and zeros
+            if (self.scale > 0) {
+                l += 1 + self.scale;
+            }
+            return l;
         }
 
-        l += self.number_of_digits * 4;
-        // there's no integer in the number, but our string output will have
-        // a leading 0  (so it'll be 0.123 instead of just .123)
-        if (self.weight < 0) {
+        var frac_digits: usize = 0;
+
+        // Example 1.
+        // 12345678.9012 -> weight = 1 (1234*10000^1 + 5678*10000^0 + 9012*10000^-1), number_of_digits = 3 {1234, 5678, 9012}
+        // Example 2.
+        // 100000000000 -> weight = 2 (1000*10000^2 + 0*10000^1 + 0*10000^0), number_of_digits = 1 {1000} (needs 2 tail zero groups)
+        // Example 3.
+        // 0.000000000001 -> weight = -3 (0*10000^-1 + 0*10000^-2 + 1*10000^-3) , number_of_digits = 1 {1} (needs 2 leading zero groups)
+        if (self.weight >= 0) {
+            const int_groups_count: usize = @intCast(self.weight + 1);
+            // for Example 1: (1+1) * 4 = 8 -> 12345678.9012 integer part contains 8 digits
+            // for Example 2: (2+1) * 4 = 12 -> 100000000000
+            l += int_groups_count * 4;
+
+            if (self.number_of_digits > int_groups_count) {
+                // for Example 1: 3 > 2 -> (3-2) * 4 = 4 -> 9012 fraction part contains 4 digits
+                frac_digits = (self.number_of_digits - int_groups_count) * 4;
+            }
+        } else {
+            // there's no integer in the number, but our string output will have
+            // a leading 0  (so it'll be 0.123 instead of just .123)
             l += 1;
+            frac_digits = self.number_of_digits * 4;
 
             if (self.weight < -1) {
                 const missing_groups: usize = @intCast(-1 - self.weight);
-                l += missing_groups * 4;
+                // for Example 3: (-1 - (-3)) * 4 = 8 -> 00000000 (8 missing fraction zeros)
+                frac_digits += missing_groups * 4;
             }
+        }
+
+        // only allocate for fraction if scale > 0
+        if (self.scale > 0) {
+            l += 1 + @max(frac_digits, @as(usize, self.scale));
         }
 
         return l;
@@ -207,16 +236,27 @@ pub const Numeric = struct {
         }
 
         if (number_of_digits == 0) {
-            const end = pos + 3;
-            @memcpy(buf[pos..end], "0.0");
-            return buf[0..end];
+            buf[pos] = '0';
+            pos += 1;
+
+            // if we have something like 0.000::numeric -> should print 0.000
+            // otherwise, without fractin, e.g. 0::numeric -> should print 0
+            if (self.scale > 0) {
+                buf[pos] = '.';
+                pos += 1;
+                @memset(buf[pos .. pos + self.scale], '0');
+                pos += self.scale;
+            }
+            return buf[0..pos];
         }
 
         // do the integer part first
         if (weight < 0) {
+            // if number is less than 1 -> always print 0 as integer part
             buf[pos] = '0';
             pos += 1;
         } else {
+            var is_first_group = true;
             while (weight >= 0) {
                 if (digits.len == 0) {
                     const end = pos + 4;
@@ -224,55 +264,86 @@ pub const Numeric = struct {
                     pos = end;
                 } else {
                     const t = std.mem.readInt(i16, digits[0..2], .big);
+                    if (!is_first_group) {
+                        // internal groups should contains 4 digits,
+                        // otherwise we could get from 10005 -> 15 because of "1" + "5",
+                        // not of "1" + "0005"
+                        if (t < 10) {
+                            buf[pos + 2] = '0';
+                            buf[pos + 1] = '0';
+                            buf[pos] = '0';
+                            pos += 3;
+                        } else if (t < 100) {
+                            buf[pos + 1] = '0';
+                            buf[pos] = '0';
+                            pos += 2;
+                        } else if (t < 1000) {
+                            buf[pos] = '0';
+                            pos += 1;
+                        }
+                    }
                     pos += (try std.fmt.bufPrint(buf[pos..], "{d}", .{t})).len;
                     digits = digits[2..];
+                    is_first_group = false;
                 }
                 weight -= 1;
             }
         }
 
-        buf[pos] = '.';
-        pos += 1;
-
         // now the fraction
-        if (digits.len == 0) {
-            buf[pos] = '0';
+        // only when postgres asked, e.g. select 0.00::numeric -> scale = 2
+        // if something like select 0::numeric, skipping fraction
+        if (self.scale > 0) {
+            buf[pos] = '.';
             pos += 1;
-        } else {
-            while (weight < -1) {
-                @memcpy(buf[pos .. pos + 4], "0000");
-                pos += 4;
-                weight += 1;
-            }
 
-            while (digits.len > 0) {
-                const t = std.mem.readInt(i16, digits[0..2], .big);
-                if (t < 10) {
-                    buf[pos + 2] = '0';
-                    buf[pos + 1] = '0';
-                    buf[pos] = '0';
-                    pos += 3;
-                } else if (t < 100) {
-                    buf[pos + 1] = '0';
-                    buf[pos] = '0';
-                    pos += 2;
-                } else if (t < 1000) {
-                    buf[pos] = '0';
-                    pos += 1;
+            if (digits.len == 0) {
+                // if we have no fraction, but received from postgres to fill with zeros
+                // e.g. select 0.00::numeric
+                @memset(buf[pos .. pos + self.scale], '0');
+                pos += self.scale;
+            } else {
+                const frac_start = pos;
+
+                // filling leading zeros after dot
+                while (weight < -1) {
+                    @memcpy(buf[pos .. pos + 4], "0000");
+                    pos += 4;
+                    weight += 1;
                 }
-                pos += (try std.fmt.bufPrint(buf[pos..], "{d}", .{t})).len;
-                digits = digits[2..];
+
+                while (digits.len > 0) {
+                    const t = std.mem.readInt(i16, digits[0..2], .big);
+                    if (t < 10) {
+                        buf[pos + 2] = '0';
+                        buf[pos + 1] = '0';
+                        buf[pos] = '0';
+                        pos += 3;
+                    } else if (t < 100) {
+                        buf[pos + 1] = '0';
+                        buf[pos] = '0';
+                        pos += 2;
+                    } else if (t < 1000) {
+                        buf[pos] = '0';
+                        pos += 1;
+                    }
+                    pos += (try std.fmt.bufPrint(buf[pos..], "{d}", .{t})).len;
+                    digits = digits[2..];
+                }
+
+                const current_frac_len = pos - frac_start;
+                if (current_frac_len > self.scale) {
+                    // truncating
+                    pos -= (current_frac_len - self.scale);
+                } else if (current_frac_len < self.scale) {
+                    // padding with zeros
+                    const missing = self.scale - current_frac_len;
+                    @memset(buf[pos .. pos + missing], '0');
+                    pos += missing;
+                }
             }
         }
 
-        // we wrote the fraction in 4-digit groups, but our scale (aka display scale)
-        // might indicate that we should have less precision. For example, we might
-        // have written 0.1230, but the scale might be 3, in which case we should
-        // have written 0.123.
-        const display_scale = @mod(self.scale, 4);
-        if (display_scale > 0) {
-            pos -= 4 - display_scale;
-        }
         return buf[0..pos];
     }
 };

--- a/src/types/numeric.zig
+++ b/src/types/numeric.zig
@@ -149,8 +149,7 @@ pub const Numeric = struct {
     }
 
     pub fn estimatedStringLen(self: Numeric) usize {
-        // for the decimal point
-        var l: usize = 1;
+        var l: usize = 0;
         switch (self.sign) {
             .nan => return 3,
             .inf => return 3,
@@ -159,7 +158,6 @@ pub const Numeric = struct {
             .positive => {},
         }
 
-        // max size per base-10000 digit
         if (self.number_of_digits == 0) {
             l += 1;
             // if we have something like 0.000::numeric -> should add '.' and zeros
@@ -178,7 +176,7 @@ pub const Numeric = struct {
         // Example 3.
         // 0.000000000001 -> weight = -3 (0*10000^-1 + 0*10000^-2 + 1*10000^-3) , number_of_digits = 1 {1} (needs 2 leading zero groups)
         if (self.weight >= 0) {
-            const int_groups_count: usize = @intCast(self.weight + 1);
+            const int_groups_count = @as(usize, @intCast(self.weight)) + 1;
             // for Example 1: (1+1) * 4 = 8 -> 12345678.9012 integer part contains 8 digits
             // for Example 2: (2+1) * 4 = 12 -> 100000000000
             l += int_groups_count * 4;
@@ -240,7 +238,7 @@ pub const Numeric = struct {
             pos += 1;
 
             // if we have something like 0.000::numeric -> should print 0.000
-            // otherwise, without fractin, e.g. 0::numeric -> should print 0
+            // otherwise, without fraction, e.g. 0::numeric -> should print 0
             if (self.scale > 0) {
                 buf[pos] = '.';
                 pos += 1;
@@ -265,9 +263,9 @@ pub const Numeric = struct {
                 } else {
                     const t = std.mem.readInt(i16, digits[0..2], .big);
                     if (!is_first_group) {
-                        // internal groups should contains 4 digits,
+                        // internal groups should contain 4 digits,
                         // otherwise we could get from 10005 -> 15 because of "1" + "5",
-                        // not of "1" + "0005"
+                        // instead of "1" + "0005"
                         if (t < 10) {
                             buf[pos + 2] = '0';
                             buf[pos + 1] = '0';


### PR DESCRIPTION
Fixes a bug in `toString()` and `estimatedStringLen()` in `numeric.zig` where leading zero groups for numbers smaller than `0.0001` (when `weight < -1`) were ignored.

PostgreSQL skips leading base-10000 zero groups at the start of the fractional part and decreases `weight` instead. Previously, `toString()` failed to pad these missing zero groups, turning e.g. `0.000001` into `0.01`. Additionally, `estimatedStringLen()` ignored these zero groups and did not allocate enough memory to store the full fractional part.

Added test coverage for tiny decimals to demonstrate the issue and prevent regressions.